### PR TITLE
Fixed OnMouseDownAsButton triggering when clicking a UI element

### DIFF
--- a/Assets/Scripts/Controllers/Character.cs
+++ b/Assets/Scripts/Controllers/Character.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using System;
 using TMPro;
+using UnityEngine.EventSystems;
 
 public class Character : MonoBehaviour
 {
@@ -337,6 +338,7 @@ public class Character : MonoBehaviour
     public void Wait()
     {
         DeactivateCharacter();
+        Tile.ResetTiles?.Invoke();
     }
 
     /// <summary>
@@ -349,7 +351,7 @@ public class Character : MonoBehaviour
 
     private void OnMouseUpAsButton()
     {
-        if (canAct == true)
+        if (canAct == true && !EventSystem.current.IsPointerOverGameObject())
             SelectCharacter();
     }
 

--- a/Assets/Scripts/TileScripts/Tile.cs
+++ b/Assets/Scripts/TileScripts/Tile.cs
@@ -11,6 +11,7 @@ using System.Collections;
 using System.Collections.Generic;
 using Unity.VisualScripting;
 using UnityEngine;
+using UnityEngine.EventSystems;
 
 [SelectionBase]
 public class Tile : MonoBehaviour
@@ -128,7 +129,7 @@ public class Tile : MonoBehaviour
 
     private void OnMouseUpAsButton()
     {
-        if(currentState != TileState.idle)
+        if(currentState != TileState.idle && !EventSystem.current.IsPointerOverGameObject())
         {
             TileSelected?.Invoke(this);
         }


### PR DESCRIPTION
Character should no longer perform actions when clicking a UI button that is over an activated tile.